### PR TITLE
Check for infoArray

### DIFF
--- a/lib/hd4/device.js
+++ b/lib/hd4/device.js
@@ -240,14 +240,16 @@ class HDDevice extends HDBase {
    * @return void
    **/
   hardwareInfoOverlay(device, infoArray) {
-    if (infoArray.display_x) {
-      device.Device.hd_specs.display_x = infoArray.display_x;
-    }
-    if (infoArray.display_y) {
-      device.Device.hd_specs.display_y = infoArray.display_y;
-    }
-    if (infoArray.display_pixel_ratio) {
-      device.Device.hd_specs.display_pixel_ratio = infoArray.display_pixel_ratio;
+    if (infoArray) {
+      if (infoArray.display_x) {
+        device.Device.hd_specs.display_x = infoArray.display_x;
+      }
+      if (infoArray.display_y) {
+        device.Device.hd_specs.display_y = infoArray.display_y;
+      }
+      if (infoArray.display_pixel_ratio) {
+        device.Device.hd_specs.display_pixel_ratio = infoArray.display_pixel_ratio;
+      }
     }
   }
 


### PR DESCRIPTION
This should fix the error listed below: 
TypeError: Cannot read property 'display_x' of null
    at HDDevice.hardwareInfoOverlay ( ......./ @handsetdetection/apikit/lib/hd4/device.js:243:18)